### PR TITLE
Build conditionally an example which uses a header not found in OSG 3.0....

### DIFF
--- a/cookbook/CMakeLists.txt
+++ b/cookbook/CMakeLists.txt
@@ -1,5 +1,7 @@
 PROJECT(OSG_Cookbook)
 
+INCLUDE (CheckIncludeFiles)
+
 IF(WIN32)
     IF(MSVC)
         ADD_DEFINITIONS(-D_SCL_SECURE_NO_WARNINGS)

--- a/cookbook/chapter6/CMakeLists.txt
+++ b/cookbook/chapter6/CMakeLists.txt
@@ -4,10 +4,13 @@ SET(EXAMPLE_FILES ch06_01/bump_mapping.cpp)
 START_EXAMPLE()
 
 # Example 2: Simulating the view-dependent shadow
-SET(EXAMPLE_NAME cookbook_06_02)
-SET(EXAMPLE_FILES ch06_02/shadow.cpp)
-SET(EXTERNAL_LIBRARIES "debug;osgShadow${CMAKE_DEBUG_POSTFIX};optimized;osgShadow")
-START_EXAMPLE()
+CHECK_INCLUDE_FILES (osgShadow/ViewDependentShadowMap HAVE_VIEWDEPENDENTSHADOWMAP_H)
+IF(HAVE_VIEWDEPENDENTSHADOWMAP_H)
+  SET(EXAMPLE_NAME cookbook_06_02)
+  SET(EXAMPLE_FILES ch06_02/shadow.cpp)
+  SET(EXTERNAL_LIBRARIES "debug;osgShadow${CMAKE_DEBUG_POSTFIX};optimized;osgShadow")
+  START_EXAMPLE()
+ENDIF(HAVE_VIEWDEPENDENTSHADOWMAP_H)
 
 # Example 3: Implementing transparency with multiple passes
 SET(EXAMPLE_NAME cookbook_06_03)


### PR DESCRIPTION
...1 release.

Hi, current stable release 3.0.1 lacks the ViewDependentShadowMap header. Although a new stable release is coming soon and hopefully will match the book's release, I think this will save some head scratching for people using older (or current) versions of OSG 3.
