### PR TITLE
The expression RAND_MAX+1 overflows on Linux as RAND_MAX is defined as 2...

### DIFF
--- a/cookbook/chapter4/ch04_04/radar_map.cpp
+++ b/cookbook/chapter4/ch04_04/radar_map.cpp
@@ -14,7 +14,7 @@
 
 const unsigned int MAIN_CAMERA_MASK = 0x1;
 const unsigned int RADAR_CAMERA_MASK = 0x2;
-#define RAND(min, max) ((min) + (float)rand()/(RAND_MAX+1) * ((max)-(min)))
+#define RAND(min, max) ((min) + (float)rand()/(RAND_MAX) * ((max)-(min)))
 
 osg::Node* createObject( const std::string& filename, const osg::Vec4& color )
 {

--- a/cookbook/chapter5/ch05_03/scroll_texts.cpp
+++ b/cookbook/chapter5/ch05_03/scroll_texts.cpp
@@ -11,7 +11,7 @@
 
 #include "CommonFunctions"
 
-#define RAND(min, max) ((min) + (float)rand()/(RAND_MAX+1) * ((max)-(min)))
+#define RAND(min, max) ((min) + (float)rand()/(RAND_MAX) * ((max)-(min)))
 
 class ScrollTextCallback : public osg::Drawable::UpdateCallback
 {

--- a/cookbook/chapter5/ch05_08/Player
+++ b/cookbook/chapter5/ch05_08/Player
@@ -8,7 +8,7 @@
 
 #include <osg/MatrixTransform>
 #include <osgGA/GUIEventAdapter>
-#define RAND(min, max) ((min) + (float)rand()/(RAND_MAX+1) * ((max)-(min)))
+#define RAND(min, max) ((min) + (float)rand()/(RAND_MAX) * ((max)-(min)))
 
 class Player : public osg::MatrixTransform
 {


### PR DESCRIPTION
...147483647.

Hi, when compiling, GCC emits several messages of the type "warning: integer overflow in expression [-Woverflow]". This happens because at least on this environment RAND_MAX+1 is overflowing. Since the source code is just for demonstration, removing the "+1" seems to be fine.
