### PR TITLE
Make sure to call traverse from NodeCallbacks

### DIFF
--- a/cookbook/chapter2/ch02_01/observer_ptr.cpp
+++ b/cookbook/chapter2/ch02_01/observer_ptr.cpp
@@ -30,6 +30,7 @@ public:
         if ( _drawable1.valid() ) content += "Drawable 1; ";
         if ( _drawable2.valid() ) content += "Drawable 2; ";
         if ( _text.valid() ) _text->setText( content );
+        traverse(node, nv);
     }
     
     osg::ref_ptr<osgText::Text> _text;

--- a/cookbook/chapter2/ch02_03/bounding_box.cpp
+++ b/cookbook/chapter2/ch02_03/bounding_box.cpp
@@ -33,6 +33,8 @@ public:
         trans->setMatrix(
             osg::Matrix::scale(bb.xMax()-bb.xMin(), bb.yMax()-bb.yMin(), bb.zMax()-bb.zMin()) *
             osg::Matrix::translate(bb.center()) );
+
+        traverse(node, nv);
     }
     
     osg::NodePath _nodesToCompute;


### PR DESCRIPTION
traverse() has to be called from NodeCallbacks, so that the UpdateVisitor can process the rest of the scene graph. 

See the documentation: https://github.com/openscenegraph/osg/blob/master/src/osg/Callback.cpp#L86